### PR TITLE
PR: Add O3-mini model and update Perplexity models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,9 +90,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.28"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e77c3243bd94243c03672cb5154667347c457ca271254724f9f393aee1c05ff"
+checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.27"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
 dependencies = [
  "anstream",
  "anstyle",
@@ -220,9 +220,9 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "lock_api"
@@ -236,9 +236,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "mio"
@@ -320,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
 dependencies = [
  "bitflags 2.8.0",
 ]
@@ -365,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "strsim"
@@ -407,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "token_calculator"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "clap",
  "inquire",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "token_calculator"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The CLI will ask you for the provider, for example 'openai', and the model you w
 - `gtp-4o-mini`: The OpenAI GPT-4o-mini model.
 - `o1`: The OpenAI O1 model.
 - `o1-mini`: The OpenAI O1 Mini model.
+- `o3-mini`: The OpenAI O3 Mini model.
 - `gpt-3.5-turbo`: The OpenAI GPT-3.5 model.
 - `gpt-3.5-turbo-instruct`: The OpenAI GPT-3.5 Turbo Instruct model.
 - `gpt-4-turbo`: The OpenAI GPT-4 Turbo model.
@@ -60,9 +61,8 @@ The CLI will ask you for the provider, for example 'openai', and the model you w
 - `sonar-pro`: The Perplexity AI Sonar Pro model.
 - `sonar-reasoning`: The Perplexity AI Sonar Reasoning model.
 - `sonar-reasoning-pro`: The Perplexity AI Sonar Reasoning Pro model.
-- `llama-3.1-sonar-small-128k-online`: The Perplexity AI Llama 3.1 Sonar Small 128k Online model (deprecated from 22/02/2025).
-- `llama-3.1-sonar-large-128k-online`: The Perplexity AI Llama 3.1 Sonar Large 128k Online model (deprecated from 22/02/2025).
-- `llama-3.1-sonar-huge-128k-online`: The Perplexity AI Llama 3.1 Sonar Huge 128k Online model (deprecated from 22/02/2025).
+- `sonar-deep-research`: The Perplexity AI Sonar Deep Research model.
+- `r1-1776`: The Perplexity AI R1 1776 model.
 
 ### Groq
 

--- a/src/prices.rs
+++ b/src/prices.rs
@@ -13,13 +13,12 @@ pub fn get_google_model_prices(model: &str) -> (f32, f32) {
 
 pub fn get_perplexity_model_prices(model: &str) -> (f32, f32) {
     match model {
-        "llama-3.1-sonar-small-128k-online" => (0.0002, 0.0002),
-        "llama-3.1-sonar-large-128k-online" => (0.001, 0.001),
-        "llama-3.1-sonar-huge-128k-online" => (0.005, 0.005),
         "sonar" => (0.001, 0.001),
         "sonar-pro" => (0.003, 0.015),
         "sonar-reasoning" => (0.001, 0.005),
         "sonar-reasoning-pro" => (0.002, 0.008),
+        "sonar-deep-research" => (0.002, 0.008),
+        "r1-1776" => (0.002, 0.008),
         _ => (0.001, 0.001)
     }
 }
@@ -34,7 +33,8 @@ pub fn get_openai_model_prices(model: &str) -> (f32, f32) {
         "gpt-4o" => (0.0025, 0.01),
         "gpt-4o-mini" => (0.00015, 0.0006),
         "o1" => (0.015, 0.06),
-        "o1-mini" => (0.0030, 0.012),
+        "o1-mini" => (0.0011, 0.0044),
+        "o3-mini" => (0.0011, 0.0044),
         _ => (0.005, 0.015)
     }
 }
@@ -79,6 +79,7 @@ pub fn get_provider_models(provider: &str) -> Vec<&str> {
             "gpt-3.5-turbo-instruct",
             "o1",
             "o1-mini",
+            "o3-mini",
         ],
         "google" => vec![
             "gemini-1-pro",
@@ -94,6 +95,8 @@ pub fn get_provider_models(provider: &str) -> Vec<&str> {
             "sonar-pro",
             "sonar-reasoning",
             "sonar-reasoning-pro",
+            "sonar-deep-research",
+            "r1-1776",
         ],
         "groq" => vec![
             "gemma2-9b-it",
@@ -128,6 +131,20 @@ mod tests {
         let (input_price, output_price) = get_model_prices("openai", "gpt-4o");
         assert_eq!(input_price, 0.0025);
         assert_eq!(output_price, 0.01);
+    }
+
+    #[test]
+    fn test_get_model_prices_o1_mini() {
+        let (input_price, output_price) = get_model_prices("openai", "o1-mini");
+        assert_eq!(input_price, 0.0011);
+        assert_eq!(output_price, 0.0044);
+    }
+
+    #[test]
+    fn test_get_model_prices_o3_mini() {
+        let (input_price, output_price) = get_model_prices("openai", "o3-mini");
+        assert_eq!(input_price, 0.0011);
+        assert_eq!(output_price, 0.0044);
     }
 
     #[test]
@@ -248,4 +265,20 @@ mod tests {
         assert_eq!(input_price, 0.001);
         assert_eq!(output_price, 0.001);
     }
+
+    #[test]
+    fn test_get_model_prices_perplexity_sonar_deep_research() {
+        let (input_price, output_price) = get_model_prices("perplexity", "sonar-deep-research");
+        assert_eq!(input_price, 0.002);
+        assert_eq!(output_price, 0.008);
+    }
+
+    #[test]
+    fn test_get_model_prices_perplexity_r1_1776() {
+        let (input_price, output_price) = get_model_prices("perplexity", "r1-1776");
+        assert_eq!(input_price, 0.002);
+        assert_eq!(output_price, 0.008);
+    }
+    
+    
 }


### PR DESCRIPTION
## Changes

This PR updates the token calculator with the following changes:

### Added Models
- Added OpenAI's new `o3-mini` model with pricing ($0.0011/1K input tokens, $0.0044/1K output tokens)
- Added Perplexity's `sonar-deep-research` model ($0.002/1K input tokens, $0.008/1K output tokens)
- Added Perplexity's `r1-1776` model ($0.002/1K input tokens, $0.008/1K output tokens)

### Updated Models
- Updated pricing for OpenAI's `o1-mini` model from $0.0030/1K input tokens and $0.012/1K output tokens to $0.0011/1K input tokens and $0.0044/1K output tokens

### Removed Models
- Removed deprecated Perplexity models:
  - `llama-3.1-sonar-small-128k-online`
  - `llama-3.1-sonar-large-128k-online`
  - `llama-3.1-sonar-huge-128k-online`

### Other Changes
- Updated README.md to reflect the model changes
- Incremented version from 0.15.0 to 0.16.0 in Cargo.toml
- Added corresponding unit tests for the new models

## Testing
All tests pass for the new and updated models.