### PR TITLE
Add GitHub Actions workflow for building artifacts

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -1,0 +1,63 @@
+name: Build Artifacts
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  # Optionally trigger on push to specific branches if desired
+  # push:
+  #   branches: [ "feature/**" ]
+
+jobs:
+  build:
+    name: Build ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            artifact_name: token_calculator-linux
+            asset_name: token_calculator-linux
+          - os: windows-latest
+            artifact_name: token_calculator-windows
+            asset_name: token_calculator-windows.exe
+          - os: macos-latest
+            artifact_name: token_calculator-macos
+            asset_name: token_calculator-macos
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Setup Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+    
+    - name: Build
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --release
+    
+    - name: Prepare artifacts (Windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        mkdir artifacts
+        copy target/release/token_calculator.exe artifacts/${{ matrix.asset_name }}
+      shell: pwsh
+    
+    - name: Prepare artifacts (Unix)
+      if: matrix.os != 'windows-latest'
+      run: |
+        mkdir artifacts
+        cp target/release/token_calculator artifacts/${{ matrix.asset_name }}
+    
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.artifact_name }}
+        path: artifacts/${{ matrix.asset_name }}
+        retention-days: 30


### PR DESCRIPTION
## Changes

This PR adds a new GitHub Actions workflow that builds the token_calculator application for multiple platforms:

- Added `.github/workflows/build-artifacts.yml` which:
  - Builds the application for Linux, Windows, and macOS
  - Creates platform-specific artifacts with appropriate naming
  - Uploads the built binaries as GitHub artifacts
  - Sets a 30-day retention period for the artifacts

## Features

- **Cross-platform builds**: Automatically builds for Linux, Windows, and macOS
- **Manual triggering**: Can be triggered manually from the Actions tab
- **Configurable**: Includes commented code for automatic triggering on pushes to feature branches
- **Artifact management**: Properly names and uploads artifacts for each platform

## Implementation Details

- Uses GitHub Actions matrix strategy to build for multiple platforms in parallel
- Employs platform-specific commands for artifact preparation
- Utilizes official Rust GitHub Actions for toolchain setup and building
- Ensures proper naming conventions for each platform's executable

This workflow will make it easier to test and distribute the token_calculator application across different operating systems without manual builds.